### PR TITLE
feature multiple selection with serialized arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,60 @@ Once a changed value has been saved, the previous value disappears from the list
 This is to prevent records from becoming invalid as the list of assignable values evolves. This also prevents `<select>` menus with blank selections when opening an old record in a web form.
 
 
+Multiple selection
+------------------
+
+You can restrict the values but allow multiple selections using serialized arrays:
+
+    class Recording
+
+      serialize :formats, Array 
+
+      assignable_values_for :formats do
+        %w[ep lp single]
+      end
+
+    end
+    
+Now, each assigned array value is checked during validation:
+
+    Recording.new(:formats => ['lp','ep']).valid?        # => true
+    Recording.new(:formats => ['lp', 'elephant').valid?  # => false
+    
+An error is added for every invalid array element.
+
+
+### blank values
+
+For convenience, restricted multiple selection attributes allow the blank value (the empty array) by default. Keep in mind that `nil` will result in an empty array for serialized arrays.  
+
+If you would like to change this behavior and disallow blank values, set `:allow_blank` option to false.
+
+Remember that values are only validated when they change. Thus, if a blank array remains unchanged it is still valid, regardingless the `:allow_blank` option.    
+
+### Humanized output for multiple selection
+
+By default, the humanized output is the array of the humanized values joined by ", ".
+
+    recording = Recording.new(:formats => ['lp', 'ep'])
+    recording.humanized_formats                          # => "Long play, Extended play"
+
+You can override the separator with the `:separator` option:
+
+    class Recording
+
+      serialize :formats, Array 
+
+      assignable_values_for :formats, :separator => "/" do
+        %w[ep lp single]
+      end
+
+    end
+    
+    recording = Recording.new(:formats => ['lp', 'ep'])
+    recording.humanized_formats                          # => "Long play/Extended play"
+
+
 Restricting belongs_to associations
 -----------------------------------
 

--- a/lib/assignable_values.rb
+++ b/lib/assignable_values.rb
@@ -1,7 +1,6 @@
 require 'assignable_values/errors'
 require 'assignable_values/active_record'
-require 'assignable_values/active_record/restriction/base'
-require 'assignable_values/active_record/restriction/belongs_to_association'
-require 'assignable_values/active_record/restriction/scalar_attribute'
+require 'assignable_values/active_record/restriction'
+require 'assignable_values/active_record/restriction/type_factory'
 require 'assignable_values/humanized_value'
 

--- a/lib/assignable_values/active_record.rb
+++ b/lib/assignable_values/active_record.rb
@@ -4,13 +4,8 @@ module AssignableValues
     private
 
     def assignable_values_for(property, options = {}, &values)
-      restriction_type = belongs_to_association?(property) ? Restriction::BelongsToAssociation : Restriction::ScalarAttribute
+      restriction_type = Restriction.type_for(self, property)
       restriction_type.new(self, property, options, &values)
-    end
-
-    def belongs_to_association?(property)
-      reflection = reflect_on_association(property)
-      reflection && reflection.macro == :belongs_to
     end
 
   end

--- a/lib/assignable_values/active_record/restriction.rb
+++ b/lib/assignable_values/active_record/restriction.rb
@@ -1,0 +1,13 @@
+module AssignableValues
+  module ActiveRecord
+    module Restriction
+      
+      def self.type_for(model, property)
+        factory = TypeFactory.new(model)
+        factory.get(property)
+      end
+            
+    end
+  end
+end
+

--- a/lib/assignable_values/active_record/restriction/scalar_attribute.rb
+++ b/lib/assignable_values/active_record/restriction/scalar_attribute.rb
@@ -8,13 +8,16 @@ module AssignableValues
           define_humanized_value_method
           define_humanized_values_method
         end
+        
+        def dictionary_scope
+          "assignable_values.#{model.name.underscore}.#{property}"
+        end
 
         def humanized_value(values, value) # we take the values because that contains the humanizations in case humanizations are hard-coded as a hash
           if value.present?
             if values.respond_to?(:humanizations)
               values.humanizations[value]
             else
-              dictionary_scope = "assignable_values.#{model.name.underscore}.#{property}"
               I18n.t(value, :scope => dictionary_scope, :default => default_humanization_for_value(value))
             end
           end
@@ -67,11 +70,21 @@ module AssignableValues
             end
           end
         end
+        
+        def humanized_values_method_name
+          restriction = self
+          if restriction.property.to_s.pluralize == restriction.property.to_s
+            "available_humanized_#{restriction.property.to_s.pluralize}"
+          else
+            "humanized_#{restriction.property.to_s.pluralize}"
+          end
+        end
 
         def define_humanized_values_method
           restriction = self
+          name = humanized_values_method_name
           enhance_model do
-            define_method "humanized_#{restriction.property.to_s.pluralize}" do
+            define_method name do
               restriction.humanized_values(self)
             end
           end

--- a/lib/assignable_values/active_record/restriction/serialized_array_attribute.rb
+++ b/lib/assignable_values/active_record/restriction/serialized_array_attribute.rb
@@ -1,0 +1,51 @@
+module AssignableValues
+  module ActiveRecord
+    module Restriction
+      class SerializedArrayAttribute < ScalarAttribute
+        
+        def humanized_value(values, value)
+          value.map{|v| super(values, v)}.join(separator)
+        end
+        
+        def validate_value(record, values)
+          if values.blank? && ! (allow_blank? || skip_blank?(record))
+            record.errors.add(property, cant_be_blank_error_message)
+          else
+            values.each do |value|
+              unless assignable_value?(record, value)
+                record.errors.add(property, not_included_error_message)
+              end
+            end
+          end
+        end
+                
+        private
+        
+        def values_to_skip_validation(record)
+          previously_saved_value(record) || []
+        end
+        
+        # for multiple selections, allow_blank == true is a convenient default 
+        def allow_blank?
+          if @options.has_key?(:allow_blank)
+            super
+          else
+            true
+          end
+        end
+        
+        # if the previous value was blank, we still want to stay with 
+        # the default to skip validation for unchanged values
+        def skip_blank?(record)
+          return false if record.new_record?
+          ! previously_saved_value(record).present?
+        end
+        
+        def separator
+          @options[:separator] || ', '
+        end
+        
+      end
+    end
+  end
+end

--- a/lib/assignable_values/active_record/restriction/type_factory.rb
+++ b/lib/assignable_values/active_record/restriction/type_factory.rb
@@ -1,0 +1,46 @@
+require 'assignable_values/active_record/restriction/base'
+require 'assignable_values/active_record/restriction/belongs_to_association'
+require 'assignable_values/active_record/restriction/scalar_attribute'
+require 'assignable_values/active_record/restriction/serialized_array_attribute'
+module AssignableValues
+  module ActiveRecord
+    module Restriction
+      class TypeFactory
+
+        attr_reader :model
+        
+        def initialize(model)
+          @model = model
+        end
+        
+        def get(property)
+          if belongs_to_association?(property)
+            BelongsToAssociation
+          elsif serialized_array?(property)
+            SerializedArrayAttribute 
+          else
+            ScalarAttribute
+          end
+        end
+        
+        private
+        
+        def belongs_to_association?(property)
+          reflection = model.reflect_on_association(property)
+          reflection && reflection.macro == :belongs_to
+        end
+        
+        def serialized_array?(property)
+          serialization = model.serialized_attributes[property.to_s]
+          if serialization.respond_to?(:object_class) # since rails 3.2
+            serialization.object_class == Array
+          else 
+            serialization == Array
+          end
+        end
+
+      end
+    end
+  end
+end
+

--- a/spec/shared/app_root/app/models/recording/vinyl.rb
+++ b/spec/shared/app_root/app/models/recording/vinyl.rb
@@ -1,5 +1,7 @@
 module Recording
   class Vinyl < ActiveRecord::Base
     self.table_name = 'vinyl_recordings'
+    
+    serialize :formats, Array
   end
 end

--- a/spec/shared/app_root/config/locales/en.yml
+++ b/spec/shared/app_root/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
   errors:
     messages:
       inclusion: "is not included in the list"
+      blank: "can't be blank"
 
   assignable_values:
     song:
@@ -21,3 +22,7 @@ en:
         '1977': 'The year a new hope was born'
         '1980': 'The year the Empire stroke back'
         '1983': 'The year the Jedi returned'
+      formats:
+        lp: 'Long play'
+        ep: 'Extended play'
+        single: 'Single'

--- a/spec/shared/app_root/db/migrate/003_create_recordings.rb
+++ b/spec/shared/app_root/db/migrate/003_create_recordings.rb
@@ -3,6 +3,7 @@ class CreateRecordings < ActiveRecord::Migration
   def self.up
     create_table :vinyl_recordings do |t|
       t.integer :year
+      t.string :formats
     end
   end
 


### PR DESCRIPTION
As discussed, for multiple selection and restricted by assignable_values, let's use a serialized array.

Regarding usage, please check the README.md #multiple-selection. For all cases listed you will find according tests added to the active_record_spec.rb.

For any question or further required changes, don't hesitate to contact me.
