### PR TITLE
Add a status option

### DIFF
--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -6,14 +6,15 @@ module AssignableValues
         attr_reader :model, :property, :options, :values, :default, :secondary_default
 
         def initialize(model, property, options, &values)
-          @model = model
+          @model    = model
           @property = property
-          @options = options
-          @values = values
+          @options  = options
+          @values   = values
           ensure_values_given
           setup_default
           define_assignable_values_method
           setup_validation
+          define_status_methods
         end
 
         def validate_record(record)
@@ -127,6 +128,10 @@ module AssignableValues
           evaluate_option(record, @options[:allow_blank])
         end
 
+        def statusable?
+          @options[:status]
+        end
+
         def delegate_definition
           options[:through]
         end
@@ -137,6 +142,10 @@ module AssignableValues
 
         def enhance_model(&block)
           @model.class_eval(&block)
+        end
+
+        def enhance_instance(&block)
+          @model.instance_eval(&block)
         end
 
         def setup_default
@@ -177,6 +186,38 @@ module AssignableValues
             end
             validate validate_method
           end
+        end
+
+        def define_status_methods
+          return unless statusable?
+          collisions = model.methods & status_method_array(self)
+          if collisions.present?
+            raise MethodCollision, "Status assignment collision(s): #{collisions*', '}"
+          else
+            define_check_methods self
+          end
+        end
+
+        def status_method_array(record)
+          parsed_values(record) + query_methods(record)
+        end
+
+        def query_methods(record)
+          parsed_values(record).map{ |x| x+'?' }
+        end
+
+        def define_check_methods(record)
+          parsed_values(record).each do |value|
+            enhance_instance do
+              define_method "#{value}?" do
+                self.send(property.to_sym) == value
+              end
+            end
+          end
+        end
+
+        def parsed_values(record)
+          parsed_assignable_values(record)[:values]
         end
 
         def define_assignable_values_method

--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -193,8 +193,6 @@ module AssignableValues
           collisions = model.methods & status_method_array(self)
           if collisions.present?
             raise MethodCollision, "Status assignment collision(s): #{collisions*', '}"
-          else
-            define_check_methods self
           end
         end
 
@@ -204,16 +202,6 @@ module AssignableValues
 
         def query_methods(record)
           parsed_values(record).map{ |x| x+'?' }
-        end
-
-        def define_check_methods(record)
-          parsed_values(record).each do |value|
-            enhance_instance do
-              define_method "#{value}?" do
-                record.send(property.to_sym) == value
-              end
-            end
-          end
         end
 
         def parsed_values(record)

--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -210,7 +210,7 @@ module AssignableValues
           parsed_values(record).each do |value|
             enhance_instance do
               define_method "#{value}?" do
-                self.send(property.to_sym) == value
+                record.send(property.to_sym) == value
               end
             end
           end

--- a/lib/assignable_values/active_record/restriction/scalar_attribute.rb
+++ b/lib/assignable_values/active_record/restriction/scalar_attribute.rb
@@ -9,6 +9,7 @@ module AssignableValues
           define_humanized_value_class_method
           define_humanized_values_instance_method
           define_query_class_methods
+          define_checker_instance_methods
         end
 
         def humanized_value(values, value) # we take the values because that contains the humanizations in case humanizations are hard-coded as a hash
@@ -66,6 +67,20 @@ module AssignableValues
             enhance_model_singleton do
               define_method "#{value}" do
                 restriction.model.where(restriction.property => value)
+              end
+            end
+          end
+        end
+
+        def define_checker_instance_methods
+          return unless self.options[:status]
+          restriction = self
+
+          restriction.assignable_values(self).each do |value|
+            next unless value
+            enhance_model do
+              define_method "#{value}?" do
+                send(:"#{restriction.property}") == value
               end
             end
           end

--- a/lib/assignable_values/active_record/restriction/scalar_attribute.rb
+++ b/lib/assignable_values/active_record/restriction/scalar_attribute.rb
@@ -8,6 +8,7 @@ module AssignableValues
           define_humanized_value_instance_method
           define_humanized_value_class_method
           define_humanized_values_instance_method
+          define_query_class_methods
         end
 
         def humanized_value(values, value) # we take the values because that contains the humanizations in case humanizations are hard-coded as a hash
@@ -52,6 +53,20 @@ module AssignableValues
           enhance_model_singleton do
             define_method "humanized_#{restriction.property}" do |given_value|
               restriction.humanized_value(nil, given_value)
+            end
+          end
+        end
+
+        def define_query_class_methods
+          return unless self.options[:status]
+          restriction = self
+
+          restriction.assignable_values(self).each do |value|
+            next unless value
+            enhance_model_singleton do
+              define_method "#{value}" do
+                restriction.where(restriction.property => value)
+              end
             end
           end
         end

--- a/lib/assignable_values/active_record/restriction/scalar_attribute.rb
+++ b/lib/assignable_values/active_record/restriction/scalar_attribute.rb
@@ -65,7 +65,7 @@ module AssignableValues
             next unless value
             enhance_model_singleton do
               define_method "#{value}" do
-                restriction.where(restriction.property => value)
+                restriction.model.where(restriction.property => value)
               end
             end
           end

--- a/lib/assignable_values/errors.rb
+++ b/lib/assignable_values/errors.rb
@@ -3,4 +3,5 @@ module AssignableValues
   class DelegateUnavailable < Error; end
   class NoValuesGiven < Error; end
   class NoDefault < Error; end
+  class MethodCollision < Error; end
 end

--- a/lib/assignable_values/version.rb
+++ b/lib/assignable_values/version.rb
@@ -1,3 +1,3 @@
 module AssignableValues
-  VERSION = '0.11.1'
+  VERSION = '0.11.4'
 end

--- a/spec/rails-3.0/.bundle/config
+++ b/spec/rails-3.0/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_WITHOUT: development

--- a/spec/rails-3.0/Gemfile.lock
+++ b/spec/rails-3.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    assignable_values (0.11.0)
+    assignable_values (0.11.1)
       activerecord
 
 GEM

--- a/spec/rails-3.0/Gemfile.lock
+++ b/spec/rails-3.0/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    assignable_values (0.11.1)
+    assignable_values (0.11.4)
       activerecord
 
 GEM

--- a/spec/rails-3.2/.bundle/config
+++ b/spec/rails-3.2/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_WITHOUT: development

--- a/spec/rails-3.2/Gemfile.lock
+++ b/spec/rails-3.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    assignable_values (0.11.0)
+    assignable_values (0.11.1)
       activerecord
 
 GEM

--- a/spec/rails-3.2/Gemfile.lock
+++ b/spec/rails-3.2/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    assignable_values (0.11.1)
+    assignable_values (0.11.4)
       activerecord
 
 GEM

--- a/spec/rails-4.1/.bundle/config
+++ b/spec/rails-4.1/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_WITHOUT: development

--- a/spec/rails-4.1/Gemfile.lock
+++ b/spec/rails-4.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    assignable_values (0.11.0)
+    assignable_values (0.11.1)
       activerecord
 
 GEM

--- a/spec/rails-4.1/Gemfile.lock
+++ b/spec/rails-4.1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    assignable_values (0.11.1)
+    assignable_values (0.11.4)
       activerecord
 
 GEM

--- a/spec/shared/assignable_values/active_record_spec.rb
+++ b/spec/shared/assignable_values/active_record_spec.rb
@@ -135,6 +135,13 @@ describe AssignableValues::ActiveRecord do
           @klass.new.should respond_to :pop?
           @klass.new.should respond_to :rock?
         end
+
+        it 'should work properly' do
+          @klass.new(:genre => 'pop').pop?.should   == true
+          @klass.new(:genre => 'rock').pop?.should  == false
+          @klass.new(:genre => 'rock').rock?.should == true
+          @klass.new(:genre => 'pop').rock?.should  == false
+        end
       end
 
       context 'if the :allow_blank option is set to a symbol that refers to an instance method' do

--- a/spec/shared/assignable_values/active_record_spec.rb
+++ b/spec/shared/assignable_values/active_record_spec.rb
@@ -119,6 +119,22 @@ describe AssignableValues::ActiveRecord do
 
       end
 
+      context 'if the :status option is set to true' do
+
+        before :each do
+          @klass = Song.disposable_copy do
+            assignable_values_for :genre, :status => true do
+              %w[pop rock]
+            end
+          end
+        end
+
+        it 'should define proper methods' do
+          @klass.new.should respond_to :pop?
+          @klass.new.should respond_to :rock?
+        end
+      end
+
       context 'if the :allow_blank option is set to a symbol that refers to an instance method' do
 
         before :each do

--- a/spec/shared/assignable_values/active_record_spec.rb
+++ b/spec/shared/assignable_values/active_record_spec.rb
@@ -130,6 +130,8 @@ describe AssignableValues::ActiveRecord do
         end
 
         it 'should define proper methods' do
+          @klass.should respond_to :pop
+          @klass.should respond_to :rock
           @klass.new.should respond_to :pop?
           @klass.new.should respond_to :rock?
         end


### PR DESCRIPTION
This adds an option "status" which makes the field "statusable".  This defines query methods on the class and checker methods on instances.

For instance, in the following class

```
class Song
  assignable_values_for :genre, status: true do 
    %w(pop rock techno)
  end
end
```

the class and instances of it will behave like so:

```
song = Song.new(genre: 'pop')
# song responds to .pop?, .rock?, and .techno? now
# song.{value}? checks song.{property} == {value}
# Song responds to .pop, .rock, .techno
# Song.{value} queries Song.where(property => value)
song.pop?
  => true
song.techno?
  => false
Song.pop
  => AR relation with song
```
