### PR TITLE
Supress DEPRECATION warning for rails 5.1

### DIFF
--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -179,7 +179,7 @@ module AssignableValues
             define_method validate_method do
               restriction.validate_record(self)
             end
-            validate validate_method
+            validate validate_method.to_sym
           end
         end
 


### PR DESCRIPTION
In rails 5.1 passing string to define callback is deprecated
