### PR TITLE
fixed arity-bug

### DIFF
--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -240,7 +240,7 @@ module AssignableValues
           delegate = delegate(record)
           delegate.present? or raise DelegateUnavailable, "Cannot query a nil delegate for assignable values"
           delegate_query_method = :"assignable_#{model.name.underscore.gsub('/', '_')}_#{property.to_s.pluralize}"
-          args = delegate.method(delegate_query_method).arity == 1 ? [record] : []
+          args = delegate.method(delegate_query_method).arity == 0 ? [] : [record]
           delegate.send(delegate_query_method, *args)
         end
 


### PR DESCRIPTION
I encountered a bug using assignable_values and Consul.
Consul memoizes its power methods with [wegowise/memoizer](https://github.com/wegowise/memoizer), which itself has a bug. It memoizes a method but the stubbed method is always accepting variable arguments. Thus their arity is negative, even if the original method has a positive arity.

assignable_values could not deal with that, because `args = delegate.method(delegate_query_method).arity == 1 ? [record] : []` would return an empty array for a memoized method.

I fixed the issue, tested it and repaired the resulting broken tests.