### PR TITLE
when given a scope, do not load all records to memory during validation (fixes #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+- when given a scope, do not load all records to memory during validation
 
 ## 0.16.1 - 2019-05-14
 


### PR DESCRIPTION
I could not find a good solution for rails 2 as the `scope.exists?`-call still loaded records from the database. But maybe that's not super relevant.