### PR TITLE
When assigning nil, do not crash when assignable values are a scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+## 0.16.3 - 2020-10-15
+
+### Compatible changes
+
+- No longer crashes when assigning `nil` to an attribute with assignable values that are provided as a scope.
+
 ## 0.16.2 - 2020-10-06
 
 ### Compatible changes

--- a/Gemfile.2.3.lock
+++ b/Gemfile.2.3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.2)
+    assignable_values (0.16.3)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.3.2.lock
+++ b/Gemfile.3.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.2)
+    assignable_values (0.16.3)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.4.2.lock
+++ b/Gemfile.4.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.2)
+    assignable_values (0.16.3)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.0.lock
+++ b/Gemfile.5.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.2)
+    assignable_values (0.16.3)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.1.lock
+++ b/Gemfile.5.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.2)
+    assignable_values (0.16.3)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.1.pg.lock
+++ b/Gemfile.5.1.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.2)
+    assignable_values (0.16.3)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.6.0.pg.lock
+++ b/Gemfile.6.0.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.2)
+    assignable_values (0.16.3)
       activerecord (>= 2.3)
 
 GEM

--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -107,7 +107,7 @@ module AssignableValues
           values_or_scope = assignable_values(record, :include_old_value => false)
 
           if is_scope?(values_or_scope)
-            values_or_scope.exists?(value.id)
+            values_or_scope.exists?(value.id) unless value.nil?
           else
             values_or_scope.include?(value)
           end

--- a/lib/assignable_values/version.rb
+++ b/lib/assignable_values/version.rb
@@ -1,3 +1,3 @@
 module AssignableValues
-  VERSION = '0.16.2'
+  VERSION = '0.16.3'
 end


### PR DESCRIPTION
Last version broke `nil` assignment to attributes with assignable values using a scope. This fixes it.