### PR TITLE
Fix value blocks that return nil from causing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,26 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Compatible changes
 
+## 0.16.4 - 2020-10-15
+
+### Compatible changes
+
+- No longer crashes value blocks return `nil`.
+
+
 ## 0.16.3 - 2020-10-15
 
 ### Compatible changes
 
 - No longer crashes when assigning `nil` to an attribute with assignable values that are provided as a scope.
 
+
 ## 0.16.2 - 2020-10-06
 
 ### Compatible changes
 
 - when given a scope, do not load all records to memory during validation
+
 
 ## 0.16.1 - 2019-05-14
 

--- a/Gemfile.2.3.lock
+++ b/Gemfile.2.3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.3)
+    assignable_values (0.16.4)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.3.2.lock
+++ b/Gemfile.3.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.3)
+    assignable_values (0.16.4)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.4.2.lock
+++ b/Gemfile.4.2.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.3)
+    assignable_values (0.16.4)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.0.lock
+++ b/Gemfile.5.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.3)
+    assignable_values (0.16.4)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.1.lock
+++ b/Gemfile.5.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.3)
+    assignable_values (0.16.4)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.1.pg.lock
+++ b/Gemfile.5.1.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.3)
+    assignable_values (0.16.4)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.6.0.pg.lock
+++ b/Gemfile.6.0.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (0.16.3)
+    assignable_values (0.16.4)
       activerecord (>= 2.3)
 
 GEM

--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -236,10 +236,16 @@ module AssignableValues
         end
 
         def assignable_values_from_record_or_delegate(record)
-          if delegate?
+          assignable_values = if delegate?
             assignable_values_from_delegate(record)
           else
             record.instance_exec(&@values)
+          end
+
+          if is_scope?(assignable_values)
+            assignable_values
+          else
+            Array(assignable_values)
           end
         end
 

--- a/lib/assignable_values/version.rb
+++ b/lib/assignable_values/version.rb
@@ -1,3 +1,3 @@
 module AssignableValues
-  VERSION = '0.16.3'
+  VERSION = '0.16.4'
 end

--- a/spec/assignable_values/active_record_spec.rb
+++ b/spec/assignable_values/active_record_spec.rb
@@ -808,6 +808,26 @@ describe AssignableValues::ActiveRecord do
         klass.new.assignable_genres.should == %w[pop rock]
       end
 
+      it 'returns an array when the value block returns a single value' do
+        klass = Song.disposable_copy do
+          assignable_values_for :genre do
+            'techno'
+          end
+        end
+
+        klass.new.assignable_genres.should == ['techno']
+      end
+
+      it 'returns an empty array when the value block returns nothing' do
+        klass = Song.disposable_copy do
+          assignable_values_for :genre do
+            nil
+          end
+        end
+
+        klass.new.assignable_genres.should == []
+      end
+
       it 'should prepend a previously saved value to the top of the list, even if is no longer allowed' do
         klass = Song.disposable_copy do
           assignable_values_for :genre do


### PR DESCRIPTION
Example:

```ruby
assignable_values_for :genre do
  %[pop rock] if year >= 1950
end
```

Previously, this would return an empty array. Since 0.16.2 this caused errors when accessing `assignable_genres`:

```ruby
     NoMethodError:
       undefined method `include?' for nil:NilClass
```

Here is a fix for that.