### PR TITLE
Use the magic of CollectionAssociation#include?

### DIFF
--- a/lib/assignable_values/active_record/restriction/base.rb
+++ b/lib/assignable_values/active_record/restriction/base.rb
@@ -105,12 +105,7 @@ module AssignableValues
 
         def included_in_assignable_values?(record, value)
           values_or_scope = assignable_values(record, :include_old_value => false)
-
-          if is_scope?(values_or_scope)
-            values_or_scope.exists?(value.id) unless value.nil?
-          else
-            values_or_scope.include?(value)
-          end
+          values_or_scope.include?(value)
         end
 
         def is_scope?(object)


### PR DESCRIPTION
Use CollectionAssociation#include? to check whether a record exists in a scope.
Since at least [Rails 4.0](https://github.com/rails/rails/blob/375d9a0a7fb329b0fbbd75a13e93e53a00520587/activerecord/lib/active_record/associations/collection_association.rb#L343) (and apparently [even before](https://apidock.com/rails/v2.1.0/ActiveRecord/Associations/AssociationCollection/include%3F)), this will use `exists?` if the association isn't loaded and `include?` (without speaking to the database again) if it is.
Additionally (and the main reason for this PR): If the scope contains unsaved values (eg. by using `scope.build`), these values are also allowed.