### PR TITLE
Hook into railties correctly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
         ruby-version: "${{ matrix.ruby }}"
     - name: Setup database
       run: |
+        sudo apt-get update
         sudo apt-get install -y postgresql-client
         PGPASSWORD=postgres psql -c 'create database assignable_values_test;' -U postgres -p 5432 -h localhost
     - name: Bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 -
 
+## 1.0.1 - 2024-08-27
+
+- Hook into railties correctly
+
 ## 1.0.0 - 2024-02-14
 
 - This gem has been in productive use for 12 years now, time for a 1.0 release! 🥳

--- a/Gemfile.5.0.lock
+++ b/Gemfile.5.0.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (1.0.0)
+    assignable_values (1.0.1)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.1.lock
+++ b/Gemfile.5.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (1.0.0)
+    assignable_values (1.0.1)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.5.1.pg.lock
+++ b/Gemfile.5.1.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (1.0.0)
+    assignable_values (1.0.1)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.6.1.pg.lock
+++ b/Gemfile.6.1.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (1.0.0)
+    assignable_values (1.0.1)
       activerecord (>= 2.3)
 
 GEM

--- a/Gemfile.7.1.pg.lock
+++ b/Gemfile.7.1.pg.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    assignable_values (1.0.0)
+    assignable_values (1.0.1)
       activerecord (>= 2.3)
 
 GEM

--- a/lib/assignable_values/active_record.rb
+++ b/lib/assignable_values/active_record.rb
@@ -16,5 +16,6 @@ module AssignableValues
   end
 end
 
-ActiveRecord::Base.send(:extend, AssignableValues::ActiveRecord)
-
+ActiveSupport.on_load(:active_record) do
+  extend(AssignableValues::ActiveRecord)
+end

--- a/lib/assignable_values/version.rb
+++ b/lib/assignable_values/version.rb
@@ -1,3 +1,3 @@
 module AssignableValues
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
Use `ActiveSupport.on_load` to not break the load order of Rails.